### PR TITLE
removed optimism from the docs

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -26,7 +26,8 @@ module.exports = {
             },
             {"Staking Contracts": ["contracts/delegatorFactory","contracts/delegator"]}
         ],
-        "Optimism": ["optimism"],
+//        Note: commented this section as we dropped support for optimism.
+//        "Optimism": ["optimism"],
         "Arbitrum": ["arbitrum"],
         "Audits": ["audits"],
     },


### PR DESCRIPTION
Commented out the optimism section as we dropped support for it. Also, I'm keeping it as a comment and not removing the actual file so that we can uncomment it when add support for it again. 